### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoIoTCloudBearSSL
-version=1.1.1
+version=1.1.2
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Port of BearSSL to Arduino.

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,5 @@ paragraph=This library depends on ArduinoECCX08.
 category=Communication
 url=http://www.arduino.cc/en/Reference/ArduinoBearSSL
 architectures=*
+depends=ArduinoECCX08
 includes=ArduinoIoTCloudBearSSL.h


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format